### PR TITLE
fix: Upload coverage report in separate workflow

### DIFF
--- a/.github/workflows/pre-submit.dependabot.codecov.yml
+++ b/.github/workflows/pre-submit.dependabot.codecov.yml
@@ -1,0 +1,37 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Dependabot Codecov
+
+on:
+  workflow_run:
+    workflows: ["tests"]
+    types:
+      - completed:
+
+jobs:
+  codecov:
+    name: Upload coverage to CodeCov
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download coverage reports
+        uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
+        with:
+          name: "cobertura-coverage.xml"
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: "cobertura-coverage.xml"
+          fail_ci_if_error: true

--- a/.github/workflows/pre-submit.dependabot.codecov.yml
+++ b/.github/workflows/pre-submit.dependabot.codecov.yml
@@ -17,8 +17,7 @@ name: Dependabot Codecov
 on:
   workflow_run:
     workflows: ["tests"]
-    types:
-      - completed:
+    types: ["completed"]
 
 jobs:
   codecov:

--- a/.github/workflows/pre-submit.units.yml
+++ b/.github/workflows/pre-submit.units.yml
@@ -40,12 +40,19 @@ jobs:
       - name: unit tests
         run: |
           make unit-test
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4
+      - name: Upload coverage reports
+        uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: "coverage/cobertura-coverage.xml"
-          fail_ci_if_error: true
+          name: "cobertura-coverage.xml"
+          path: "coverage/cobertura-coverage.xml"
+
+      # TODO: remove
+      # - name: Upload coverage reports to Codecov
+      #   uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4
+      #   with:
+      #     token: ${{ secrets.CODECOV_TOKEN }}
+      #     files: "coverage/cobertura-coverage.xml"
+      #     fail_ci_if_error: true
 
   # check-dist for actions
   ###############################


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->

**Description:**

Fixes an issue with dependabot PRs where `codecov-action` fails due to lack of access to secrets. This uploads coverage reports as an artifact and downloads them in a separate workflow triggered when the `tests` workflow is complete.

**Related Issues:**

Updates #355 

**Checklist:**

- [x] Review the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [CHANGELOG.md](../blob/main/CHANGELOG.md) if applicable.
- [x] Sign the [Google CLA](https://cla.developers.google.com/about/google-corporate).
