### PR TITLE
test: don't depend on map order

### DIFF
--- a/__tests__/reopener.test.ts
+++ b/__tests__/reopener.test.ts
@@ -291,12 +291,13 @@ describe("getTODOIssues", () => {
     await expect(p).resolves.toHaveLength(2);
     let issues = await p;
 
-    // NOTE: This may be flaky depending on Map implementation.
-    // TODO: Update test to not depend on order of Map.values()
-    expect(issues[0].issueID).toBe(123);
-    expect(issues[0].todos).toHaveLength(2);
-    expect(issues[1].issueID).toBe(456);
-    expect(issues[1].todos).toHaveLength(1);
+    const issue123 = issues.find((i) => i.issueID == 123);
+    expect(issue123).toBeDefined();
+    expect(issue123!.todos).toHaveLength(2);
+
+    const issue456 = issues.find((i) => i.issueID == 456);
+    expect(issue456).toBeDefined();
+    expect(issue456!.todos).toHaveLength(1);
   });
 
   it("handles todos error", async () => {


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->

**Description:**

Fixes a test that depended on the order of the return value of `Map.values`.

**Related Issues:**

N/A

**Checklist:**

- [x] Review the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [CHANGELOG.md](../blob/main/CHANGELOG.md) if applicable.
- [x] Sign the [Google CLA](https://cla.developers.google.com/about/google-corporate).
